### PR TITLE
Use modern autopilot_state to correctly illuminate NAV for GPSS

### DIFF
--- a/Honeycomb Bravo.lua
+++ b/Honeycomb Bravo.lua
@@ -1570,8 +1570,6 @@ local LED_ANC_DOOR =		{4, 4}
     -- Datarefs configuration for Default Aircrafts.
 
 	-- Autopilot
-	local hdg = dataref_table('sim/cockpit2/autopilot/heading_mode')
-	local nav = dataref_table('sim/cockpit2/autopilot/nav_status')
 	local apr = dataref_table('sim/cockpit2/autopilot/approach_status')
 	local rev = dataref_table('sim/cockpit2/autopilot/backcourse_status')
 	local alt = dataref_table('sim/cockpit2/autopilot/altitude_hold_status')

--- a/Honeycomb Bravo.lua
+++ b/Honeycomb Bravo.lua
@@ -1579,6 +1579,7 @@ local LED_ANC_DOOR =		{4, 4}
 	local ias = dataref_table('sim/cockpit2/autopilot/autothrottle_on')
 
 	local ap = dataref_table('sim/cockpit2/autopilot/servos_on')
+	local autopilot_state = dataref_table("sim/cockpit/autopilot/autopilot_state") -- see https://developer.x-plane.com/article/accessing-the-x-plane-autopilot-from-datarefs/
 
 	-- Landing gear LEDs
 	local gear = dataref_table('sim/flightmodel2/gear/deploy_ratio')
@@ -1608,11 +1609,19 @@ local LED_ANC_DOOR =		{4, 4}
 		if bus_voltage[0] > 0 then
 			master_state = true
 
-			-- HDG
-			set_led(LED_FCU_HDG, get_ap_state(hdg))
-
-			-- NAV
-			set_led(LED_FCU_NAV, get_ap_state(nav))
+			-- HDG & NAV
+			if bitwise.band(autopilot_state[0], 2) > 0 then
+				-- Heading Select Engage
+				set_led(LED_FCU_HDG, true)
+				set_led(LED_FCU_NAV, false)
+			elseif bitwise.band(autopilot_state[0], 512) > 0 or bitwise.band(autopilot_state[0], 524288) > 0 then
+				-- Nav Engaged or GPSS Engaged
+				set_led(LED_FCU_HDG, false)
+				set_led(LED_FCU_NAV, true)
+			else
+				set_led(LED_FCU_HDG, false)
+				set_led(LED_FCU_NAV, false)
+			end
 
 			-- APR
 			set_led(LED_FCU_APR, get_ap_state(apr))


### PR DESCRIPTION
This fixes the autopilot state lights on the C172. I have added this to the default aircraft profile with the goal of eventually removing the C172 customisations.