### PR TITLE
C750: support the Citation X

### DIFF
--- a/Honeycomb Bravo.lua
+++ b/Honeycomb Bravo.lua
@@ -1566,6 +1566,10 @@ local LED_ANC_DOOR =		{4, 4}
 	-- Change LEDs when their underlying dataref changes
 	-- Bus voltage as a master LED switch
 	local bus_voltage = dataref_table('sim/cockpit2/electrical/bus_volts')
+	if PLANE_ICAO == "C750" then
+		-- On the C750 bus_volts is only on when the Standby Power is on, but the lights and indicators in the sim are on before that
+		bus_voltage = dataref_table('laminar/CitX/APU/DC_volts')
+	end
 
     -- Datarefs configuration for Default Aircrafts.
 
@@ -1651,7 +1655,13 @@ local LED_ANC_DOOR =		{4, 4}
 			set_led(LED_FCU_VS, get_ap_state(vs))
 
 			-- IAS
-			set_led(LED_FCU_IAS, get_ap_state(ias))
+			if bitwise.band(autopilot_state[0], 8) > 0 then
+				-- Speed-by-pitch Engage AKA Flight Level Change
+				-- See "Aliasing of Flight-Level Change With Speed Change" on https://developer.x-plane.com/article/accessing-the-x-plane-autopilot-from-datarefs/
+				set_led(LED_FCU_IAS, true)
+			else
+				set_led(LED_FCU_IAS, get_ap_state(ias))
+			end
 
 			-- AUTOPILOT
 			set_led(LED_FCU_AP, int_to_bool(ap[0]))

--- a/Honeycomb Bravo.lua
+++ b/Honeycomb Bravo.lua
@@ -1579,6 +1579,7 @@ local LED_ANC_DOOR =		{4, 4}
 	local ias = dataref_table('sim/cockpit2/autopilot/autothrottle_on')
 
 	local ap = dataref_table('sim/cockpit2/autopilot/servos_on')
+	local autopilot_state = dataref_table("sim/cockpit/autopilot/autopilot_state") -- see https://developer.x-plane.com/article/accessing-the-x-plane-autopilot-from-datarefs/
 
 	-- Landing gear LEDs
 	local gear = dataref_table('sim/flightmodel2/gear/deploy_ratio')
@@ -1608,11 +1609,26 @@ local LED_ANC_DOOR =		{4, 4}
 		if bus_voltage[0] > 0 then
 			master_state = true
 
-			-- HDG
-			set_led(LED_FCU_HDG, get_ap_state(hdg))
+			-- HDG & NAV
+			if bitwise.band(autopilot_state[0], 2) > 0 then
+				-- Heading Select Engage
+				set_led(LED_FCU_HDG, true)
+				set_led(LED_FCU_NAV, false)
+			elseif bitwise.band(autopilot_state[0], 512) > 0 or bitwise.band(autopilot_state[0], 524288) > 0 then
+				-- Nav Engaged or GPSS Engaged
+				set_led(LED_FCU_HDG, false)
+				set_led(LED_FCU_NAV, true)
+			elseif PLANE_ICAO == "C172" or PLANE_ICAO == "SR22" then
+				-- Aircraft known to use autopilot_state
+				set_led(LED_FCU_HDG, false)
+				set_led(LED_FCU_NAV, false)
+			else
+				-- HDG
+				set_led(LED_FCU_HDG, get_ap_state(hdg))
 
-			-- NAV
-			set_led(LED_FCU_NAV, get_ap_state(nav))
+				-- NAV
+				set_led(LED_FCU_NAV, get_ap_state(nav))
+			end
 
 			-- APR
 			set_led(LED_FCU_APR, get_ap_state(apr))


### PR DESCRIPTION
This MUST be merged AFTER #6.

This builds upon the modern `autopilot_state` changes in #6 to use the same to illuminate the IAS button for FLC on the Citation X. Based on my reading of https://developer.x-plane.com/article/accessing-the-x-plane-autopilot-from-datarefs/ (see "Aliasing of Flight-Level Change With Speed Change") this is the most correct thing to do to map this autopilot state to the Bravo.